### PR TITLE
feat: adiciona menu de outras cidades

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,4 +5,4 @@ menu:
   - {name: 'Sobre', url: '/about'}
   - {name: 'Eventos', url: '/events'}
   - {name: 'Meetup', url: 'https://meetup.com/pt-BR/floripa-bitdevs', external: true}
-  - {name: 'Outras Cidades', url: '/cities'}
+  - {name: 'Cidades', url: '/cities'}

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,3 +5,4 @@ menu:
   - {name: 'Sobre', url: '/about'}
   - {name: 'Eventos', url: '/events'}
   - {name: 'Meetup', url: 'https://meetup.com/pt-BR/floripa-bitdevs', external: true}
+  - {name: 'Outras Cidades', url: '/cities'}

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -58,6 +58,7 @@
   &-logo-text {
     margin-left: 5rem;
     font-size: 2.1rem;
+    white-space: nowrap;
     @media (min-width: 768px) {
       margin-left: 4.5rem;
     }
@@ -82,6 +83,7 @@
       color: var(--font-color);
       opacity: 0.4;
       margin-right: 1rem;
+      white-space: nowrap;
 
       @media (min-width: 768px) {
         margin-right: 0;

--- a/cities.md
+++ b/cities.md
@@ -1,6 +1,7 @@
 ---
 layout: default
-title: Outras Cidades
+title: Cidades
+permalink: /cities/
 ---
 <div class="Home">
     <p class="Home-about">

--- a/cities.md
+++ b/cities.md
@@ -15,6 +15,7 @@ title: Outras Cidades
             <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
             <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
             <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+            <li><a href="https://udibitdevs.org/" target="_blank" rel="noopener nofollow">Uberlândia</a></li>
         </ul>
     </div>
 

--- a/cities.md
+++ b/cities.md
@@ -1,36 +1,29 @@
 ---
 layout: default
+title: Outras Cidades
 ---
+<div class="Home">
+    <p class="Home-about">
+        O formato BitDevs se espalhou por várias cidades do Brasil. Se você estiver viajando ou quiser conhecer outras comunidades, aqui vai uma lista com alguns grupos ativos.
+    </p>
 
-As Bitcoin has grown, so too have the local communities of like minded enthusiasts who wish to learn from one another and connect on a deeper level. Each of these communities is unique in its own way, composed of individuals from all walks of life with different ideas about what Bitcoin is and what it is not. What it can do, and what it cannot. But no matter from what lense you view Bitcoin, you cannot escape certain shared beliefs, because without them Bitcoin would not exist. One most critical is that of open source software development––"standing on the shoulder's of giants"––a principle that enables the seemingly endless chain of novel insights from which Bitcoin and its future improvements are built.
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do Brasil</h2>
+        <ul>
+            <li><a href="https://bhbitdevs.org/" target="_blank" rel="noopener nofollow">Belo Horizonte</a></li>
+            <li><a href="https://bitdevs.bsb.br/" target="_blank" rel="noopener nofollow">Brasília</a></li>
+            <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
+            <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
+            <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+        </ul>
+    </div>
 
-Inspired by this very ethos, the BitDevs NYC community fostered an in-person environment where technically focused dialogue could be used as a way of testing ideas, just in the same way software protocols are challenged in open networks. Instead of organizing meetups exclusively around presentations and lectures, events were styled as Socratic Seminars, such that open discourse underpinned each event, inviting a collaborative spirit that reflected the base principles of the Bitcoin protocol and cypherpunk spirit.
-
-Over time, the concept of BitDevs and the associated Socratic Seminar event series have spread to other cities. While the NYC community was first to stumble upon these ideas, it holds no trademark, license, branding or creative direction over the use of these terms. BitDevs, like any piece of open source code with a liberal license, is free for anyone to use and adapt to their local communities.
-
-If you find yourself interested in tapping into your local Bitcoin community, we have put together a list here of meetups which are known to regularly host in-person [Socratic Seminars](https://bitdevs.org/about). We hope you are able to attend and leave with a deeper connection to and appreciation for the Bitcoin community.
-
-As a disclaimer, BitDevs NYC has no official associations with or oversight of these meetups. In some cases we have never even spoken to the organizers. An idea, much like a hash function, is one way. If you don't like what you see, feel free to [fork it](https://github.com/BitDevsNYC/BitDevsNYC.github.io/) and [run your own](https://bitdevs.org/running-a-great-socratic-seminar/).
-
-- [Amsterdam](https://bitdevsamsterdam.org/)
-- [Atlanta](https://atlantabitdevs.org/)
-- [Austin](https://austinbitdevs.com/)
-- [Berlin](https://bitdevs.berlin/)
-- [Boston](https://bostonbitdevs.org/)
-- [Chicago](https://chibitdevs.org/)
-- [Denver](http://denverbitdevs.com/)
-- [Honolulu](http://www.honolulubitdevs.com/)
-- [London](https://londonbitdevs.org/)
-- [Los Angeles](https://bitdevsla.org/)
-- [Miami](https://miamibitdevs.org/)
-- [Minneapolis](https://bitdevsmpls.org)
-- [Paris](https://twitter.com/bitdevsfr)
-- [Portland](https://www.meetup.com/portlandbitdevs/)
-- [Raleigh / Durham / Chapel Hill](https://trianglebitdevs.org/)
-- [San Francisco](https://www.sfbitcoindevs.org/)
-- [San Juan](https://sanjuanbitdevs.org/)
-- [São Paulo](https://bitdevsportugues.org)
-- [Taipei](https://bitdevs.tw/)
-- [Tampa](https://tampabitdevs.io/)
-- [Vancouver](https://bitdevs.ca/)
-- [Washington, D.C.](https://dcbitdevs.org/)
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do mundo</h2>
+        <p>
+            <a href="https://bitdevs.org/cities" target="_blank" rel="noopener nofollow">
+                Ver a lista global mantida pelo BitDevs NYC
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
## Resumo
- adiciona a aba `Outras Cidades` no menu principal
- cria/atualiza a página `/cities` com links para os outros BitDevs do Brasil
- mantém um link separado para a lista global do BitDevs NYC

## Validação
- `git diff --check`

Closes #32
