### PR TITLE
feat: june 2026 meetup

### DIFF
--- a/_posts/2026-06-11-socratic-seminar-31.md
+++ b/_posts/2026-06-11-socratic-seminar-31.md
@@ -1,0 +1,57 @@
+---
+layout: post
+type: socratic
+title: "Seminário Socrático 31"
+meetup: https://app.evento.so/e/evt_8rW4zX3UYhkyntnj
+---
+
+## Avisos
+
+- Entrem no grupo do Whatsapp [Floripa Bitdevs](https://chat.whatsapp.com/FCQNp71ayTv4U1LNDDowXh)!
+- Entrem no [discord da Vinteum](https://discord.gg/wfXJ5ySb)
+- Os meetups nunca são gravados. Queremos todos a vontade para participar e discutir os assuntos programados, de forma anônima se assim o desejarem.
+
+## Agradecimentos
+
+- Agradecemos à Vinteum pela casa, comidas e bebidas.
+
+## Cronograma
+
+### Aquecimento
+
+* [Bitcoiner Chad Brasileiro desenvolve mapa para reunir bitdevs do Brasil](https://jaoleal.github.io/BitdevsBrasilMapa/)
+* [Welcoming conduition](https://brink.dev/blog/2026/06/01/conduition/)
+* [Btrust anuncia novo board](https://x.com/btrustteam/status/2056806271517364501)
+* [Influência dos devs do Bitcoin (Orange Dev Network)](https://sorukumar.github.io/orange-dev-network/network.html)
+* [Sparrow 2.5.0](https://github.com/sparrowwallet/sparrow/releases)
+* [LDK Server Launch](https://xcancel.com/lightningdevkit/status/2054231998458175553)
+* [Public Pool added Stratum V2 Support](https://x.com/StratumV2/status/2062959948720447919)
+* [Tradução PT-BR para o site Learn Me a Bitcoin](https://meaprendeumbitcoin.com.br/)
+
+### Bitcoin
+
+* [bitcoin-cli getmempoolcluster: Bitcoin Core v31 na prática](https://blog.areabitcoin.com.br/bitcoin-core-v31-na-pratica/)
+* [Bitcoin Core: disallow P2Pv1 connection on IPv4 and IPv6 peers](https://github.com/bitcoin/bitcoin/pull/30951)
+* [IPC-based tracing interface on Core?](https://github.com/bitcoin/bitcoin/issues/35142)
+* [Formosa becomes officially BIP450](https://github.com/bitcoin/bips/pull/2108)
+* [BIP proposal for UTXO set sharing over P2P network](https://groups.google.com/g/bitcoindev/c/rThmyI8ZN3Q) ([bips#2137](https://github.com/bitcoin/bips/issues/2137))
+* [TCP hole punching for Bitcoin nodes behind NATs](https://delvingbitcoin.org/t/tcp-hole-punching-for-bitcoin-nodes-behind-home-nats/2497)
+
+### Segurança
+
+* [Bisq Protocol Exploit, 11 BTC stolen](https://xcancel.com/bisq_network/status/2050917431699460231)
+* [Meet Loupe: AI-Powered Vulnerability Scanning for Open-Source Bitcoin](https://spiralbtc.substack.com/p/meet-loupe-ai-powered-vulnerability)
+* [Trezor's TROPIC01 chip vulnerability disclosure](https://trezor.io/blog/news/Trezor-response-TROPIC01-chip-disclosure-no-impact-to-your-funds)
+* [Rug the mints (full disclosure)](https://uncensoredtech.substack.com/p/rug-the-mints)
+
+### Privacy
+
+* [Cashu now accepts Onchain Bitcoin payments (next release)](https://github.com/cashubtc/nuts/blob/main/30.md) ([NUT PR](https://github.com/cashubtc/nuts/pull/365) & [CDK Implementation](https://github.com/cashubtc/cdk/pull/1870))
+* [Zcash e os perigos da opacificação na camada base (money printer go brrr)](https://gizmodo.com/zcash-bug-could-have-let-attackers-print-cryptocurrency-out-of-thin-air-2000767790)
+
+### Layer 2 / ZK
+
+* [Introducing Mosaic: Glock's final piece](https://www.alpenlabs.io/blog/introducing-mosaic-glocks-final-piece) ([paper](https://eprint.iacr.org/2026/812.pdf))
+* [BitVM3](https://eprint.iacr.org/2026/933)
+* [Cube: Ark + ZK](https://medium.com/cube-bitcoin/introducing-cube-8b3702e470a5)
+* [Bark now on Bitcoin mainnet](https://blog.second.tech/bark-now-on-bitcoin-mainnet/)


### PR DESCRIPTION
Schedule for the June 11, 2026 Floripa Bitdevs (Seminário Socrático 31).

Built from the diff of São Paulo Bitdevs #043 → #044, plus the link suggestions from SP issue #92 (Junho 2026). Dropped the two #044 items already covered in Floripa's May meetup (CVE-2024-52911 and BIP352/edilmedeiros). No open Floripa issues for June.

Event: https://app.evento.so/e/evt_8rW4zX3UYhkyntnj